### PR TITLE
Fix include LittleFS header

### DIFF
--- a/src/gif.cpp
+++ b/src/gif.cpp
@@ -1,5 +1,5 @@
 //#include <SD.h>
-#include <LITTLEFS.h>
+#include <LittleFS.h>
 #include <AnimatedGIF.h>
 #include <TFT_eSPI.h> 
 #include "my_debug.h"


### PR DESCRIPTION
Fix the uppercase include header of `LittleFS`.

On Linux, it will lead to a build fail : 
`src/gif.cpp:2:10: fatal error: LITTLEFS.h: No such file or directory`