### PR TITLE
Set platform 'espressif32 @ 6.6.0' and board 'esp32-s3-devkitm-1'

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -8,8 +8,18 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 [env:esp32-s3-devkitm-1]
-platform = espressif32
-board = adafruit_metro_esp32s3
+platform = espressif32 @ 6.6.0
+board = esp32-s3-devkitm-1
+
+; https://github.com/sivar2311/ESP32-S3-PlatformIO-Flash-and-PSRAM-configurations
+; ESP32-S3-WROOM-(1/1U)-N16R8
+; Flash: 16MB QD, PSRAM: 8MB OT
+board_build.arduino.memory_type = qio_opi
+board_build.flash_mode = qio
+board_build.psram_type = opi
+board_upload.flash_size = 16MB
+board_upload.maximum_size = 16777216
+
 framework = arduino
 monitor_speed = 115200
 upload_speed = 406000


### PR DESCRIPTION
 - plaform version:`espressif32 @ 6.6.0`
   - avoid error `ledcSetup and ledcAttachPin was not declared`.
 - set board to `esp32-s3-devkitm-1`
   - avoid error about `undefined reference to s3_ycbcr_convert_444`
   - error seems related to the lib `JPEGDEC` about `ESP32S3_SIMD` stuff...
   - This board is used in your other project about GeekMagic-S3 (https://github.com/GeekMagicClock/NerdMinerV2-GeekMagic-S3/blob/main/platformio.ini#L19)
   - This board was also used in this project before this commit (https://github.com/GeekMagicClock/GeekMagic-S3/commit/a4a3bbf96b3109bd2176bad50acc2f7e7825eec7#diff-4446afd728a4f34cbcddc306a9cb6be845d1a61c216076a295683bcc9c106724L13)
- memory type: `qio`
  -  avoid that esp32 keep reboot at startup
  - source: https://github.com/sivar2311/ESP32-S3-PlatformIO-Flash-and-PSRAM-configurations